### PR TITLE
Add portable installer for git-recent-switch plugin

### DIFF
--- a/apps/git-recent-switch/README.md
+++ b/apps/git-recent-switch/README.md
@@ -1,0 +1,77 @@
+# git-recent-switch
+
+`git-recent-switch` is a portable Zsh plugin that adds an interactive picker for `git switch` when no
+branch argument is provided. It prefers [`fzf`](https://github.com/junegunn/fzf) when available and falls
+back to a numbered TTY menu, making it usable across minimal environments.
+
+## Layout
+
+```
+apps/git-recent-switch/
+├── README.md
+├── init.zsh
+├── git-recent-switch.plugin.zsh
+├── completions/
+│   └── _git-recent-switch
+├── functions/
+│   └── git-recent-switch
+└── extras/
+    ├── keybind.zsh
+    └── wrapper.zsh
+```
+
+## Installation
+
+### Automated install (recommended)
+
+Run the installer script to copy the plugin into a user-scoped plugin directory.
+
+```bash
+python apps/git-recent-switch/install.py --dest "$HOME/.zsh/plugins"
+```
+
+The script is idempotent, so re-running it keeps the plugin up to date. Afterwards,
+source `init.zsh` (and any extras) from that location.
+
+```zsh
+# ~/.zshrc (after compinit)
+source "$HOME/.zsh/plugins/git-recent-switch/init.zsh"
+source "$HOME/.zsh/plugins/git-recent-switch/extras/wrapper.zsh"   # optional
+source "$HOME/.zsh/plugins/git-recent-switch/extras/keybind.zsh"   # optional
+```
+
+### Manual install
+
+Plain Zsh:
+
+```zsh
+# ~/.zshrc (after compinit)
+source ${0:h}/../apps/git-recent-switch/init.zsh
+# optional extras
+source ${0:h}/../apps/git-recent-switch/extras/wrapper.zsh
+source ${0:h}/../apps/git-recent-switch/extras/keybind.zsh
+```
+
+Oh-My-Zsh:
+
+```zsh
+ln -s "$PWD/apps/git-recent-switch" "$HOME/.oh-my-zsh/custom/plugins/git-recent-switch"
+plugins+=(git-recent-switch)
+```
+
+## Usage
+
+- Run `git-recent-switch` inside a Git repository to open the picker.
+- With the optional wrapper loaded, `git switch` (no args) opens the picker automatically.
+- The keybind extra maps `Ctrl+G` followed by `s` to trigger the picker via ZLE.
+
+## Tests
+
+Execute from the repository root:
+
+```bash
+pytest tests/test_git_recent_switch.py
+```
+
+The test suite bootstraps a temporary Git repository and asserts that the menu fallback correctly
+switches branches without `fzf` installed.

--- a/apps/git-recent-switch/completions/_git-recent-switch
+++ b/apps/git-recent-switch/completions/_git-recent-switch
@@ -1,0 +1,9 @@
+# git-recent-switch completion for local branches.
+# Usage: compdef _git-recent-switch git-recent-switch
+# Example: git-recent-switch <TAB>
+
+#compdef git-recent-switch grs
+
+local -a branches
+branches=(${(f)"$(git for-each-ref --sort=-committerdate refs/heads/ --format='%(refname:short)' 2>/dev/null)"})
+_describe 'branch' branches

--- a/apps/git-recent-switch/extras/keybind.zsh
+++ b/apps/git-recent-switch/extras/keybind.zsh
@@ -1,0 +1,13 @@
+# git-recent-switch keybind: Ctrl+G then s triggers the picker via ZLE.
+# Usage: source /path/to/extras/keybind.zsh
+# Example: source "$HOME/.zsh/plugins/git-recent-switch/extras/keybind.zsh"
+
+[[ $- == *i* ]] || return 0
+[[ -n ${_GRS_KEYBIND_LOADED-} ]] && return
+typeset -g _GRS_KEYBIND_LOADED=1
+
+function git_recent_switch_widget() {
+  zle -U "git switch"$'\n'
+}
+zle -N git_recent_switch_widget
+bindkey -s '^Gs' 'git switch\n'

--- a/apps/git-recent-switch/extras/wrapper.zsh
+++ b/apps/git-recent-switch/extras/wrapper.zsh
@@ -1,0 +1,20 @@
+# git-recent-switch wrapper: intercepts `git switch` without arguments.
+# Usage: source /path/to/extras/wrapper.zsh
+# Example: source "$HOME/.zsh/plugins/git-recent-switch/extras/wrapper.zsh"
+
+[[ -n ${_GRS_WRAPPER_LOADED-} ]] && return
+typeset -g _GRS_WRAPPER_LOADED=1
+
+if command -v git >/dev/null 2>&1; then
+  if ! typeset -f _grs_original_git >/dev/null; then
+    _grs_original_git() { command git "$@"; }
+  fi
+
+  git() {
+    if [[ "$1" == switch && -z "${2-}" ]]; then
+      git-recent-switch
+    else
+      _grs_original_git "$@"
+    fi
+  }
+fi

--- a/apps/git-recent-switch/functions/git-recent-switch
+++ b/apps/git-recent-switch/functions/git-recent-switch
@@ -1,0 +1,80 @@
+# git-recent-switch: interactive branch selector for `git switch`.
+# Usage: git-recent-switch
+# Example: git-recent-switch  # run inside a Git repository
+
+git-recent-switch() {
+  emulate -L zsh
+  setopt err_return pipefail
+
+  if ! command -v git >/dev/null 2>&1; then
+    print -u2 -- "[grs] git command not found"
+    return 127
+  fi
+
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    print -u2 -- "[grs] not inside a git repository"
+    return 2
+  fi
+
+  typeset -a recent fallback list
+  typeset -A seen
+
+  while IFS= read -r entry; do
+    [[ $entry == checkout:\ moving\ * ]] || continue
+    typeset branch=${entry##* }
+    if [[ -z ${seen[$branch]-} ]]; then
+      recent+="$branch"
+      seen[$branch]=1
+    fi
+  done < <(git reflog --format='%gs' --date=iso --all 2>/dev/null || true)
+
+  if (( ${#recent[@]} == 0 )); then
+    while IFS= read -r branch; do
+      [[ -n $branch ]] || continue
+      fallback+="$branch"
+    done < <(git for-each-ref --sort=-committerdate refs/heads/ --format='%(refname:short)' 2>/dev/null || true)
+    list=(${fallback[@]})
+  else
+    list=(${recent[@]})
+  fi
+
+  if (( ${#list[@]} == 0 )); then
+    print -u2 -- "[grs] no local branches found"
+    return 1
+  fi
+
+  typeset branch="" selection
+  if [[ -t 0 && -t 1 ]] && command -v fzf >/dev/null 2>&1; then
+    branch=$(print -lr -- ${list[@]} \
+      | fzf --height=20 --border --reverse \
+            --prompt='switch > ' \
+            --preview 'git -c color.ui=always log --oneline -n 12 --decorate --graph {}' \
+            --preview-window=right:70%)
+    [[ -n $branch ]] || return 130
+  else
+    print -r -- "[grs] fzf unavailable; showing numbered menu."
+    integer idx=1
+    for branch in ${list[@]}; do
+      printf '%2d) %s\n' idx "$branch"
+      idx=$((idx+1))
+    done
+    printf 'Pick a branch [1-%d] (Enter cancels): ' ${#list[@]}
+    if ! read -r selection; then
+      print -u2 -- "[grs] no selection received"
+      return 130
+    fi
+    [[ -n $selection ]] || return 130
+    if ! [[ $selection == <-> && $selection -ge 1 && $selection -le ${#list[@]} ]]; then
+      print -u2 -- "[grs] invalid selection"
+      return 1
+    fi
+    branch=${list[$selection]}
+  fi
+
+  if command git switch --quiet -- "$branch"; then
+    print -r -- "[grs] switched to $branch"
+    return 0
+  fi
+
+  return $?
+}

--- a/apps/git-recent-switch/git-recent-switch.plugin.zsh
+++ b/apps/git-recent-switch/git-recent-switch.plugin.zsh
@@ -1,0 +1,5 @@
+# git-recent-switch Oh-My-Zsh shim.
+# Usage: place alongside init.zsh so frameworks that auto-load *.plugin.zsh pick it up.
+# Example: ln -s apps/git-recent-switch ~/.oh-my-zsh/custom/plugins/git-recent-switch
+
+source "${0:A:h}/init.zsh"

--- a/apps/git-recent-switch/init.zsh
+++ b/apps/git-recent-switch/init.zsh
@@ -1,0 +1,26 @@
+# git-recent-switch init: source to enable the portable plugin.
+# Usage: source /path/to/apps/git-recent-switch/init.zsh
+# Example: source "$HOME/.zsh/plugins/git-recent-switch/init.zsh"
+
+[[ -n ${_GRS_PLUGIN_LOADED-} ]] && return
+typeset -g _GRS_PLUGIN_LOADED=1
+
+typeset -gU fpath
+typeset _grs_root="${0:A:h}"
+fpath=( "${_grs_root}/functions" "${_grs_root}/completions" ${fpath} )
+
+autoload -Uz git-recent-switch
+
+if [[ $- == *i* ]]; then
+  if ! typeset -f compinit >/dev/null; then
+    autoload -Uz compinit
+  fi
+  : ${ZSH_COMPDUMP:=${HOME:-${_grs_root}}/.zsh/.zcompdump}
+  mkdir -p "${ZSH_COMPDUMP:h}" 2>/dev/null || true
+  if [[ -z ${_GRS_COMPINIT_DONE-} ]]; then
+    compinit -d "${ZSH_COMPDUMP}" 2>/dev/null || true
+    typeset -g _GRS_COMPINIT_DONE=1
+  fi
+
+  alias grs='git-recent-switch'
+fi

--- a/apps/git-recent-switch/install.py
+++ b/apps/git-recent-switch/install.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Install the git-recent-switch plugin into a user-scoped plugin directory."""
+# Example: python apps/git-recent-switch/install.py --dest ~/.local/share/zsh/plugins
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+import contextlib
+
+
+def _parse_args() -> argparse.Namespace:
+  """Parse CLI arguments for the installer."""
+
+  default_dest = Path(os.path.expanduser("~/.local/share/zsh/plugins"))
+  parser = argparse.ArgumentParser(
+      description=(
+          "Install the git-recent-switch Zsh plugin into a plugin-safe directory. "
+          "The destination should be a directory that contains Zsh plugins."
+      )
+  )
+  parser.add_argument(
+      "--dest",
+      type=Path,
+      default=default_dest,
+      help=(
+          "Directory that will receive the git-recent-switch plugin. "
+          "Defaults to ~/.local/share/zsh/plugins."
+      ),
+  )
+  return parser.parse_args()
+
+
+def _copy_plugin(src: Path, dest_root: Path) -> Path:
+  """Copy the plugin directory to ``dest_root`` safely and idempotently."""
+
+  plugin_name = src.name
+  plugin_target = dest_root / plugin_name
+
+  dest_root.mkdir(parents=True, exist_ok=True)
+
+  # Stage the copy inside the destination root to ensure atomic rename.
+  staging_parent = Path(
+      tempfile.mkdtemp(prefix=f".{plugin_name}-", dir=str(dest_root))
+  )
+  staging_target = staging_parent / plugin_name
+
+  try:
+    shutil.copytree(
+        src,
+        staging_target,
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "*.pyo"),
+    )
+
+    if plugin_target.exists():
+      shutil.rmtree(plugin_target)
+
+    staging_target.rename(plugin_target)
+    staging_parent.rmdir()
+  except Exception:
+    # Clean up staging area on failure before re-raising.
+    with contextlib.suppress(Exception):
+      if staging_target.exists():
+        shutil.rmtree(staging_target)
+      staging_parent.rmdir()
+    raise
+
+  return plugin_target
+
+
+def main() -> int:
+  """Entry point for the installer script."""
+
+  args = _parse_args()
+  source_dir = Path(__file__).resolve().parent
+  destination_root = args.dest.expanduser()
+
+  try:
+    installed_path = _copy_plugin(source_dir, destination_root)
+  except PermissionError as exc:
+    print(f"[grs-install] permission denied: {exc}", file=sys.stderr)
+    return 1
+  except FileNotFoundError as exc:
+    print(f"[grs-install] missing file during install: {exc}", file=sys.stderr)
+    return 1
+  except OSError as exc:
+    print(f"[grs-install] filesystem error: {exc}", file=sys.stderr)
+    return 1
+  except Exception as exc:  # pragma: no cover - defensive safety net
+    print(f"[grs-install] unexpected error: {exc}", file=sys.stderr)
+    return 1
+
+  print(f"[grs-install] plugin installed to {installed_path}")
+  print(
+      "[grs-install] add the directory to your plugin manager or source "
+      "init.zsh manually."
+  )
+  return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - standard entry guard
+  sys.exit(main())

--- a/tests/test_git_recent_switch.py
+++ b/tests/test_git_recent_switch.py
@@ -1,0 +1,86 @@
+"""Tests for the git-recent-switch Zsh plugin."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_INIT = (REPO_ROOT / "apps" / "git-recent-switch" / "init.zsh").resolve()
+
+
+def _run(cmd: list[str], *, cwd: Path, env: dict[str, str]) -> None:
+  """Execute a command with basic error handling."""
+  subprocess.run(cmd, cwd=cwd, env=env, check=True)
+
+
+@pytest.mark.skipif(shutil.which("zsh") is None, reason="zsh shell is required for plugin tests")
+def test_git_recent_switch_tty_menu(tmp_path: Path) -> None:
+  """The fallback menu should switch to the selected branch without fzf."""
+  repo_dir = tmp_path / "repo"
+  home_dir = tmp_path / "home"
+  repo_dir.mkdir()
+  home_dir.mkdir()
+
+  env = os.environ.copy()
+  env.update(
+    {
+      "HOME": str(home_dir),
+      "PATH": "/usr/bin:/bin",
+      "GIT_AUTHOR_NAME": "Test User",
+      "GIT_AUTHOR_EMAIL": "tester@example.com",
+      "GIT_COMMITTER_NAME": "Test User",
+      "GIT_COMMITTER_EMAIL": "tester@example.com",
+    }
+  )
+  env.pop("ZDOTDIR", None)
+
+  _run(["git", "init"], cwd=repo_dir, env=env)
+  _run(["git", "checkout", "-b", "main"], cwd=repo_dir, env=env)
+
+  (repo_dir / "README.md").write_text("main\n", encoding="utf-8")
+  _run(["git", "add", "README.md"], cwd=repo_dir, env=env)
+  _run(["git", "commit", "-m", "init"], cwd=repo_dir, env=env)
+
+  _run(["git", "checkout", "-b", "feature/demo"], cwd=repo_dir, env=env)
+  (repo_dir / "feature.txt").write_text("feature\n", encoding="utf-8")
+  _run(["git", "add", "feature.txt"], cwd=repo_dir, env=env)
+  _run(["git", "commit", "-m", "feature"], cwd=repo_dir, env=env)
+
+  _run(["git", "checkout", "main"], cwd=repo_dir, env=env)
+  _run(["git", "checkout", "-b", "bugfix/handoff"], cwd=repo_dir, env=env)
+
+  shell_script = textwrap.dedent(
+    f"""
+    set -e
+    source '{PLUGIN_INIT}'
+    cd '{repo_dir.resolve()}'
+    git switch bugfix/handoff >/dev/null
+    git-recent-switch <<< '2'
+    """
+  )
+
+  result = subprocess.run(
+    ["zsh", "-c", shell_script],
+    env=env,
+    capture_output=True,
+    text=True,
+    check=True,
+  )
+
+  assert "[grs] fzf unavailable; showing numbered menu." in result.stdout
+  assert "2) main" in result.stdout
+  assert "[grs] switched to main" in result.stdout
+
+  head = subprocess.check_output(
+    ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+    cwd=repo_dir,
+    env=env,
+    text=True,
+  ).strip()
+  assert head == "main"

--- a/tests/test_git_recent_switch_install.py
+++ b/tests/test_git_recent_switch_install.py
@@ -1,0 +1,38 @@
+"""Tests for the git-recent-switch installer script."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SCRIPT = REPO_ROOT / "apps" / "git-recent-switch" / "install.py"
+
+
+@pytest.mark.skipif(not INSTALL_SCRIPT.exists(), reason="installer script missing")
+def test_install_script_idempotent(tmp_path: Path) -> None:
+  """Running the installer twice should succeed and produce a usable plugin copy."""
+
+  dest_root = tmp_path / "plugins"
+  env = os.environ.copy()
+
+  for _ in range(2):
+    subprocess.run(
+        [sys.executable, str(INSTALL_SCRIPT), "--dest", str(dest_root)],
+        check=True,
+        cwd=REPO_ROOT,
+        env=env,
+    )
+
+  installed = dest_root / "git-recent-switch"
+  assert installed.is_dir()
+  assert (installed / "init.zsh").is_file()
+  assert (installed / "functions" / "git-recent-switch").is_file()
+
+  # Ensure the install script does not leave temporary directories behind.
+  leftovers = [p for p in dest_root.iterdir() if p.name.startswith(".git-recent-switch-")]
+  assert not leftovers


### PR DESCRIPTION
## Summary
- add a portable installer script that copies git-recent-switch into a user plugin directory safely
- document the automated installation workflow and retain manual setup instructions
- cover the installer with an idempotence-focused pytest to ensure repeated installs succeed

## Testing
- pytest

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68d5795615a4832695191c6c5b0e690e